### PR TITLE
Test on "C" locale

### DIFF
--- a/t/bigfloat.t
+++ b/t/bigfloat.t
@@ -5,7 +5,7 @@ use strict;
 use warnings;
 
 use POSIX;
-setlocale(&LC_ALL, 'en_US');
+setlocale(&LC_ALL, 'C');
 
 BEGIN { use_ok('Number::Format', ':subs') }
 
@@ -18,7 +18,7 @@ SKIP:
     is($nf->round(Math::BigFloat->new(123.456), 2), '123.46', "round");
     is($nf->format_number(Math::BigFloat->new(500.27), 2, 1), '500.27');
     is($nf->format_number(Math::BigFloat->bpi(100), 7, 1), '3.1415927');
-    is($nf->format_price(Math::BigFloat->bpi(100), 4, "\$"), '$3.1416');
+    is($nf->format_price(Math::BigFloat->bpi(100), 4, "\$"), '$ 3.1416');
     is($nf->format_price(Math::BigFloat->bpi(100), 60, "\$"),
-       '$3.141592653589793238462643383279502884197169399375105820974945');
+       '$ 3.141592653589793238462643383279502884197169399375105820974945');
 }


### PR DESCRIPTION
"en_US" is not guaranteed to exist. Change currency separator
expectations accordingly -- Number::Format defaults to space.
